### PR TITLE
Header should be left to default to allow for inference of column names

### DIFF
--- a/analyses/common.py
+++ b/analyses/common.py
@@ -25,7 +25,7 @@ def _get_dir(subdir: Optional[str]):
         return ''
     return subdir + '/'
 
-def get_df(filename: str, subdir: Optional[str]=None, **kwargs):
+def get_df(filename: str, subdir: Optional[str]=None, header: Optional[Union[list[int], bool]]=None, **kwargs):
     '''Loads a CSV file into a DataFrame.
 
     Args:
@@ -38,7 +38,7 @@ def get_df(filename: str, subdir: Optional[str]=None, **kwargs):
     try:
         df = pd.read_parquet(f'data/parquet/{_get_dir(subdir)}{filename}.parquet')
     except:
-        df = pd.read_csv(f'data/csv/{_get_dir(subdir)}{filename}.csv', index_col=False, **kwargs)
+        df = pd.read_csv(f'data/csv/{_get_dir(subdir)}{filename}.csv', index_col=False, header=header, **kwargs)
         os.makedirs(f'data/parquet/{_get_dir(subdir)}', 0o755, True)
         df.to_parquet(f'data/parquet/{_get_dir(subdir)}{filename}.parquet', compression='gzip')
     return df


### PR DESCRIPTION
The present `header=None` prevents passing a different value, thus preventing inference of headers.