### PR TITLE
Automatically generate rule specifiers for tables

### DIFF
--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -66,6 +66,7 @@ def _rule_from_spec(spec) -> Tuple[int, str]:
                 rules.append(f'\\cmidrule{_trim_spec(spec[2], spec[3])}{{{spec[0]}-{spec[1]}}}')
             return (row, ' '.join(rules))
         case _:
+            print(f"Rule {spec!r} is invalid.", file=sys.err)
             return (-1, "Unhandled case")
 
 def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Optional[str]=None,
@@ -109,7 +110,7 @@ def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Op
     if mids is not None:
         if not isinstance(mids, list):
             mids = [mids]
-        rules = sorted([_rule_from_spec(mid) for mid in mids], key=lambda x: x[0])
+        rules = filter(lambda x: x[0] >= 0, sorted([_rule_from_spec(mid) for mid in mids], key=lambda x: x[0]))
         lines = tab1.splitlines()
         offset = 0
         for line, rule in rules:

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -87,13 +87,11 @@ def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Op
         styler (pandas.io.formats.style.Styler): A Pandas Styler object for formatting a table.
         filename (str): The filename to save to, including '.tex' extension. Files are saved under 'tables/'.
         subdir (Optional[str]): the sub-directory, underneath 'tables/', to save in. Defaults to None.
-        mids (Optional[Union[x=Union[int,
-                                     Tuple[int, str],
-                                     Tuple[int, Union[List[int, int, Union[bool, str], Union[bool, str]]]]],
-                             List[x]]]): Specification of mid-table rules, as follows:
-           - row : place a \midrule after this row
-           - (row, width) : place a midrule with a width of str after row
-           - (row, [(left, right, trimleft, trimright)]) : place a series of \cmidrule(trimleft,trimright){left-right} afer row
+        mids (Optional[Union[RuleSpecifier, List[RuleSpecifier]]]): Specification of mid-table rules, where a RuleSpecifier is one of the following:
+           - RuleLineIndex (an int): place a \midrule after the specified row.
+           - Tuple[RuleLineIndex, RuleWidth]: Place a \midrule[RuleWidth] after the specified row.
+           - Tuple[RuleLineIndex, Union[CmidruleSpec, List[CmidruleSpec]]] where, CmidruleSpec is Tuple[lstart: int, rstart: int, ltrim: TrimSpec, rtrim: TrimSpec] and TrimSpec is Union[bool, RuleWidth]:
+             Place a (series of) \cmidrule(ltrim rtrim){lstart-rstart} after the specified row. ltrim is 'l' if true, 'l{width}' if a RuleWidth, similarly for rtrim.
         colsep (Optional[str]): If False, use default column separators.  If a string, it is the column separator units. Defaults to False.
     '''
     if colsep:

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -82,6 +82,12 @@ def _rule_from_spec(spec: RuleSpecifier) -> ConcreteRule:
             return (-1, "Unhandled case")
 
 def auto_header_rules(df: pd.DataFrame, skip_index: bool=True, level: int=0, left_trim: TrimSpec=True, right_trim: TrimSpec=True) -> List[RuleSpecifier]:
+    """Generate post-header rule for DF, including cut rules for the column groups at LEVEL.
+
+    If skip_index is False, simply return a specification for a regular \midrule after the column header(s).
+    Otherwise, generate an offset midrule or cmidrules for groups.
+    When grouping is performed, obey LEFT_TRIM and RIGHT_TRIM between \cmidrule s
+    """
     index_cols = 1
     if isinstance(df.index, pd.MultiIndex):
         index_cols = df.index.nlevels
@@ -110,7 +116,11 @@ def auto_header_rules(df: pd.DataFrame, skip_index: bool=True, level: int=0, lef
         starts.append((cur_start + index_cols, len(values) + index_cols, left_trim, False))
         return [(df.columns.nlevels, starts)]
 
-def auto_group_rules(df: pd.DataFrame, skip_index: bool=True, level: int=0) -> List[RuleSpecifier]:
+def auto_group_rules(df: pd.DataFrame, skip_index: bool=False, level: int=0) -> List[RuleSpecifier]:
+    """Generate post-row-group rules for DF for row-groups at LEVEL.
+
+    If SKIP_INDEX is true, generate a cmidrule which does not include the columns of the index.
+    """
     assert isinstance(df.index, pd.MultiIndex), "Index must be a MultiIndex"
     row_offset = 1
     num_cols = df.columns.size

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -52,7 +52,7 @@ def _trim_spec(trim_left, trim_right):
     else:
         return ''
 
-def _rule_from_spec(spec: rule_specifier) -> Tuple[int, str]:
+def _rule_from_spec(spec) -> Tuple[int, str]:
     match spec:
         case int(row):
             return (row, '\midrule')

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -69,7 +69,12 @@ def rule_from_spec(spec: rule_specifier) -> Tuple[int, str]:
             return (-1, "Unhandled case")
 
 def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Optional[str]=None,
-               mids: Optional[Union[int,List[Union[int,Tuple[int, str], Tuple[int, Union[Tuple[int, int, Union[bool, str], Union[bool, str]], List[Tuple[int, int, Union[bool, str], Union[bool, str]]]]]]]]]=None,
+               mids: Optional[Union[int,
+                                    Tuple[int, str],
+                                    Tuple[int, Union[List[int, int, Union[bool, str], Union[bool, str]]]],
+                                    List[Union[int,
+                                               Tuple[int, str],
+                                               Tuple[int, Union[List[int, int, Union[bool, str], Union[bool, str]]]]]]]]=None,
                colsep: Optional[str]=None, **kwargs):
     '''Saves a DataFrame to a LaTeX table.
 
@@ -77,7 +82,13 @@ def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Op
         styler (pandas.io.formats.style.Styler): A Pandas Styler object for formatting a table.
         filename (str): The filename to save to, including '.tex' extension. Files are saved under 'tables/'.
         subdir (Optional[str]): the sub-directory, underneath 'tables/', to save in. Defaults to None.
-        mids (Optional[Union[int,List[Union[int, Tuple[int, List[Tuple[int, int, bool, bool]]]]]]]): If None, do not place \midrule anywhere. If a solitary int, place \midrule before it. If a list, the contents should be ints or pairs of ints and cmidrule specifications (the left column, right column, and whether or not the rule should be trimmed on the left and right). Default None.
+        mids (Optional[Union[x=Union[int,
+                                     Tuple[int, str],
+                                     Tuple[int, Union[List[int, int, Union[bool, str], Union[bool, str]]]]],
+                             List[x]]]): Specification of mid-table rules, as follows:
+           - row : place a \midrule after this row
+           - (row, width) : place a midrule with a width of str after row
+           - (row, [(left, right, trimleft, trimright)]) : place a series of \cmidrule(trimleft,trimright){left-right} afer row
         colsep (Optional[str]): If False, use default column separators.  If a string, it is the column separator units. Defaults to False.
     '''
     if colsep:

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -113,7 +113,7 @@ def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Op
         lines = tab1.splitlines()
         offset = 0
         for line, rule in rules:
-            lines.insert(offset + m + 2, rule)
+            lines.insert(offset + line + 2, rule)
             offset += 1
         tab1 = '\n'.join(lines)
 

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -52,7 +52,16 @@ def _trim_spec(trim_left, trim_right):
     else:
         return ''
 
-def _rule_from_spec(spec) -> Tuple[int, str]:
+RuleLineIndex = int
+RuleWidth = str
+TrimSpec = Union[bool, RuleWidth]
+CmidruleSpec = Tuple[int, int, TrimSpec, TrimSpec]
+RuleSpecifier = Union[RuleLineIndex,
+                       Tuple[RuleLineIndex, RuleWidth],
+                       Tuple[RuleLineIndex, Union[CmidruleSpec, List[CmidruleSpec]]]]
+ConcreteRule = Tuple[RuleLineIndex, str]
+
+def _rule_from_spec(spec: RuleSpecifier) -> ConcreteRule:
     match spec:
         case int(row):
             return (row, '\midrule')
@@ -70,12 +79,7 @@ def _rule_from_spec(spec) -> Tuple[int, str]:
             return (-1, "Unhandled case")
 
 def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Optional[str]=None,
-               mids: Optional[Union[int,
-                                    Tuple[int, str],
-                                    Tuple[int, Union[List[int, int, Union[bool, str], Union[bool, str]]]],
-                                    List[Union[int,
-                                               Tuple[int, str],
-                                               Tuple[int, Union[List[int, int, Union[bool, str], Union[bool, str]]]]]]]]=None,
+               mids: Optional[Union[RuleSpecifier, List[RuleSpecifier]]]=None,
                colsep: Optional[str]=None, **kwargs):
     '''Saves a DataFrame to a LaTeX table.
 

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -63,11 +63,11 @@ def _trim_spec(trim_left: TrimSpec, trim_right: TrimSpec) -> str:
 
 def _rule_from_spec(spec: RuleSpecifier) -> ConcreteRule:
     match spec:
-        case int(row):
+        case RuleLineIndex(row):
             return (row, '\midrule')
-        case (int(row), str(width)):
+        case (RuleLineIndex(row), RuleWidth(width)):
             return (row, f'\\midrule[{width}]')
-        case (int(row), list(specs)) | (int(row), specs):
+        case (RuleLineIndex(row), list(specs)) | (RuleLineIndex(row), specs):
             specs = specs if isinstance(specs, list) else [specs]
             specs = sorted(specs, key=lambda x: x[0])
             rules = []

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -17,6 +17,7 @@ __all__ = [
     "auto_header_rules",
     "auto_group_rules",
     ]
+
 def get_styler(df: Union[pd.DataFrame, pd.Series], decimals: Optional[int]=2, thousands: Optional[str]=',') -> pandas.io.formats.style.Styler:
     '''Gets a Styler object for formatting a table.
     

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -36,7 +36,16 @@ def highlight_rows(styler: pandas.io.formats.style.Styler) -> pandas.io.formats.
     styler = styler.applymap_index(lambda x: 'textbf:--rwrap;', axis='index')
     return styler.hide(names=True, axis='index')
 
-def _trim_spec(trim_left, trim_right):
+RuleLineIndex = int
+RuleWidth = str
+TrimSpec = Union[bool, RuleWidth]
+CmidruleSpec = Tuple[int, int, TrimSpec, TrimSpec]
+RuleSpecifier = Union[RuleLineIndex,
+                       Tuple[RuleLineIndex, RuleWidth],
+                       Tuple[RuleLineIndex, Union[CmidruleSpec, List[CmidruleSpec]]]]
+ConcreteRule = Tuple[RuleLineIndex, str]
+
+def _trim_spec(trim_left: TrimSpec, trim_right: TrimSpec) -> str:
     if trim_left or trim_right:
         trim_spec = '('
         if trim_left:
@@ -51,15 +60,6 @@ def _trim_spec(trim_left, trim_right):
         return trim_spec
     else:
         return ''
-
-RuleLineIndex = int
-RuleWidth = str
-TrimSpec = Union[bool, RuleWidth]
-CmidruleSpec = Tuple[int, int, TrimSpec, TrimSpec]
-RuleSpecifier = Union[RuleLineIndex,
-                       Tuple[RuleLineIndex, RuleWidth],
-                       Tuple[RuleLineIndex, Union[CmidruleSpec, List[CmidruleSpec]]]]
-ConcreteRule = Tuple[RuleLineIndex, str]
 
 def _rule_from_spec(spec: RuleSpecifier) -> ConcreteRule:
     match spec:

--- a/analyses/common/tables.py
+++ b/analyses/common/tables.py
@@ -52,7 +52,7 @@ def _trim_spec(trim_left, trim_right):
     else:
         return ''
 
-def rule_from_spec(spec: rule_specifier) -> Tuple[int, str]:
+def _rule_from_spec(spec: rule_specifier) -> Tuple[int, str]:
     match spec:
         case int(row):
             return (row, '\midrule')
@@ -109,7 +109,7 @@ def save_table(styler: pandas.io.formats.style.Styler, filename: str, subdir: Op
     if mids is not None:
         if not isinstance(mids, list):
             mids = [mids]
-        rules = sorted([rule_from_spec(mid) for mid in mids], key=lambda x: x[0])
+        rules = sorted([_rule_from_spec(mid) for mid in mids], key=lambda x: x[0])
         lines = tab1.splitlines()
         offset = 0
         for line, rule in rules:


### PR DESCRIPTION
This is based on #20, and can generate "defaulty" rules for both column groups and row groups.